### PR TITLE
Feature/yechan circle pages routing

### DIFF
--- a/src/wellth_app/lib/main.dart
+++ b/src/wellth_app/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:wellth_app/pages/register_page.dart';
 import 'package:wellth_app/pages/profile_page.dart';
 
 import 'package:cloud_firestore/cloud_firestore.dart'; // Used for database functionality
+import 'package:firebase_auth/firebase_auth.dart';
 
 import 'app.dart';
 import 'firebase_options.dart';
@@ -39,6 +40,7 @@ var db = FirebaseFirestore.instance;
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  await FirebaseAuth.instance.signOut();
 
   runApp(const MyApp(clientId: clientId));
 }
@@ -86,11 +88,25 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: CustomLoginPage(),
+
+      //home: CustomLoginPage(),
       //home: ProfileScreen(), // Initial screen for onboarding
       //home: OnboardingScreen_bio(),
+      home: StreamBuilder<User?>(
+        stream: FirebaseAuth.instance.authStateChanges(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            );
+          }
+          if (snapshot.hasData) {
+            return const LandingPageScreen();
+          }
+          return const CustomLoginPage();
+        },
+      ),
 
-      // onGenerateRoute 으로 인자 전달 처리
       onGenerateRoute: (RouteSettings settings) {
         final args = settings.arguments as Map<String, dynamic>?;
 
@@ -189,4 +205,3 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-

--- a/src/wellth_app/lib/pages/circles_announcement_detail_page.dart
+++ b/src/wellth_app/lib/pages/circles_announcement_detail_page.dart
@@ -121,8 +121,20 @@ class CirclesAnnouncementDetailPage extends StatelessWidget {
           currentIndex: 3,
           onTap: (index) {
             switch (index) {
+              case 0:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 1:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 2:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
               case 3:
                 Navigator.pushReplacementNamed(context, '/Circles');
+                break;
+              case 4:
+                Navigator.pushReplacementNamed(context, '/userProfile');
                 break;
               // case 0: Navigator.pushReplacementNamed(context, '/Feed'); break;
               // case 1: Navigator.pushReplacementNamed(context, '/Board'); break;

--- a/src/wellth_app/lib/pages/circles_announcement_page.dart
+++ b/src/wellth_app/lib/pages/circles_announcement_page.dart
@@ -136,8 +136,20 @@ class CirclesAnnouncementsPage extends StatelessWidget {
           currentIndex: 3,
           onTap: (index) {
             switch (index) {
+              case 0:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 1:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 2:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
               case 3:
                 Navigator.pushReplacementNamed(context, '/Circles');
+                break;
+              case 4:
+                Navigator.pushReplacementNamed(context, '/userProfile');
                 break;
               // case 0: Navigator.pushReplacementNamed(context, '/Feed'); break;
               // case 1: Navigator.pushReplacementNamed(context, '/Board'); break;

--- a/src/wellth_app/lib/pages/circles_details_page.dart
+++ b/src/wellth_app/lib/pages/circles_details_page.dart
@@ -245,8 +245,20 @@ class _CircleDetailScreenState extends State<CircleDetailScreen> {
           currentIndex: 3,
           onTap: (index) {
             switch (index) {
+              case 0:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 1:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 2:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
               case 3:
                 Navigator.pushReplacementNamed(context, '/Circles');
+                break;
+              case 4:
+                Navigator.pushReplacementNamed(context, '/userProfile');
                 break;
               // case 0: Navigator.pushReplacementNamed(context, '/Feed'); break;
               // case 1: Navigator.pushReplacementNamed(context, '/Board'); break;

--- a/src/wellth_app/lib/pages/circles_feeds_page.dart
+++ b/src/wellth_app/lib/pages/circles_feeds_page.dart
@@ -233,8 +233,20 @@ class _CircleFeedPageState extends State<CircleFeedPage> {
           currentIndex: 3,
           onTap: (index) {
             switch (index) {
+              case 0:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 1:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 2:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
               case 3:
                 Navigator.pushReplacementNamed(context, '/Circles');
+                break;
+              case 4:
+                Navigator.pushReplacementNamed(context, '/userProfile');
                 break;
               // case 0: Navigator.pushReplacementNamed(context, '/Feed'); break;
               // case 1: Navigator.pushReplacementNamed(context, '/Board'); break;

--- a/src/wellth_app/lib/pages/circles_members_page.dart
+++ b/src/wellth_app/lib/pages/circles_members_page.dart
@@ -210,8 +210,20 @@ class _CircleMembersPageState extends State<CircleMembersPage> {
           currentIndex: 3,
           onTap: (index) {
             switch (index) {
+              case 0:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 1:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 2:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
               case 3:
                 Navigator.pushReplacementNamed(context, '/Circles');
+                break;
+              case 4:
+                Navigator.pushReplacementNamed(context, '/userProfile');
                 break;
               // case 0: Navigator.pushReplacementNamed(context, '/Feed'); break;
               // case 1: Navigator.pushReplacementNamed(context, '/Board'); break;

--- a/src/wellth_app/lib/pages/circles_new_announcement_page.dart
+++ b/src/wellth_app/lib/pages/circles_new_announcement_page.dart
@@ -186,8 +186,20 @@ class _CirclesNewAnnouncementPageState
           currentIndex: 3,
           onTap: (index) {
             switch (index) {
+              case 0:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 1:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
+              case 2:
+                Navigator.pushReplacementNamed(context, '/landingPage');
+                break;
               case 3:
                 Navigator.pushReplacementNamed(context, '/Circles');
+                break;
+              case 4:
+                Navigator.pushReplacementNamed(context, '/userProfile');
                 break;
               // case 0: Navigator.pushReplacementNamed(context, '/Feed'); break;
               // case 1: Navigator.pushReplacementNamed(context, '/Board'); break;

--- a/src/wellth_app/lib/pages/circles_page.dart
+++ b/src/wellth_app/lib/pages/circles_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:wellth_app/pages/circles_details_page.dart';
+import 'package:wellth_app/circles.dart'; // fetchTop10CircleNamesAndCounts() 정의된 파일
 
 class CirclesScreen extends StatefulWidget {
   const CirclesScreen({Key? key}) : super(key: key);
@@ -10,36 +12,48 @@ class CirclesScreen extends StatefulWidget {
 
 class _CirclesScreenState extends State<CirclesScreen> {
   int selectedTab = 0; // 0: My Circles, 1: Explore
-  int _currentIndex = 3; // BottomNavigationBar highlight
-
+  int _currentIndex = 3;
   String _searchQuery = '';
 
   final List<Map<String, dynamic>> myCircles = [
-    {'name': 'Circle A', 'members': 52},
-    {'name': 'Circle B', 'members': 13},
-    {'name': 'Circle C', 'members': 5},
-    {'name': 'Circle D', 'members': 23},
+    {'name': 'Hard 75 Group', 'members': 52},
+    {'name': 'Morning Joggers', 'members': 13},
+    {'name': 'Open Mind Happy Life', 'members': 5},
+    {'name': 'Meditation Circle', 'members': 23},
+    {'name': 'Book Club', 'members': 23},
+    {'name': 'Movie Fans', 'members': 23},
+    {'name': 'Random Club', 'members': 23},
+    {'name': 'Hydration Circle', 'members': 23},
   ];
 
-  final List<Map<String, dynamic>> exploreCircles = List.generate(
-    10,
-    (i) => {'name': 'Circle ${i + 1}', 'members': 10 + i},
-  );
+  late Future<List<Map<String, dynamic>>> _exploreFuture;
 
-  void _onItemTapped(int index) {
+  @override
+  void initState() {
+    super.initState();
+    _exploreFuture = serviceCircleExploreFetchTop30Circle();
+  }
+
+  void _onNavItemTapped(int index) {
     if (index == _currentIndex) return;
     setState(() => _currentIndex = index);
+    switch (index) {
+      case 0:
+      case 1:
+      case 2:
+        Navigator.pushReplacementNamed(context, '/landingPage');
+        break;
+      case 3:
+        Navigator.pushReplacementNamed(context, '/Circles');
+        break;
+      case 4:
+        Navigator.pushReplacementNamed(context, '/userProfile');
+        break;
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    final baseList = selectedTab == 0 ? myCircles : exploreCircles;
-    final circlesToShow = baseList.where((circle) {
-      return circle['name'].toString().toLowerCase().contains(
-        _searchQuery.toLowerCase(),
-      );
-    }).toList();
-
     return Scaffold(
       backgroundColor: Colors.white,
       body: SafeArea(
@@ -52,7 +66,6 @@ class _CirclesScreenState extends State<CirclesScreen> {
               style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold),
               textAlign: TextAlign.center,
             ),
-            // const SizedBox(height: 8),
             Center(
               child: Container(
                 width: 100,
@@ -66,85 +79,17 @@ class _CirclesScreenState extends State<CirclesScreen> {
               ),
             ),
             const SizedBox(height: 16),
+
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                SizedBox(
-                  width: 140,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      gradient: selectedTab == 0
-                          ? const LinearGradient(
-                              colors: [Colors.pinkAccent, Colors.blue],
-                            )
-                          : null,
-                      color: selectedTab == 0 ? null : Colors.white,
-                      borderRadius: const BorderRadius.horizontal(
-                        left: Radius.circular(8),
-                      ),
-                      border: Border.all(color: Colors.grey),
-                    ),
-                    child: TextButton(
-                      onPressed: () => setState(() => selectedTab = 0),
-                      style: TextButton.styleFrom(
-                        backgroundColor: Colors.transparent,
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        shape: const RoundedRectangleBorder(
-                          borderRadius: BorderRadius.horizontal(
-                            left: Radius.circular(8),
-                          ),
-                        ),
-                      ),
-                      child: Text(
-                        'My Circles',
-                        style: TextStyle(
-                          color: selectedTab == 0 ? Colors.white : Colors.black,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
+                _buildTabButton('My Circles', 0, left: true),
                 const SizedBox(width: 8),
-                SizedBox(
-                  width: 140,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      gradient: selectedTab == 1
-                          ? const LinearGradient(
-                              colors: [Colors.pinkAccent, Colors.blue],
-                            )
-                          : null,
-                      color: selectedTab == 1 ? null : Colors.white,
-                      borderRadius: const BorderRadius.horizontal(
-                        right: Radius.circular(8),
-                      ),
-                      border: Border.all(color: Colors.grey),
-                    ),
-                    child: TextButton(
-                      onPressed: () => setState(() => selectedTab = 1),
-                      style: TextButton.styleFrom(
-                        backgroundColor: Colors.transparent,
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        shape: const RoundedRectangleBorder(
-                          borderRadius: BorderRadius.horizontal(
-                            right: Radius.circular(8),
-                          ),
-                        ),
-                      ),
-                      child: Text(
-                        'Explore',
-                        style: TextStyle(
-                          color: selectedTab == 1 ? Colors.white : Colors.black,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
+                _buildTabButton('Explore', 1, left: false),
               ],
             ),
             const SizedBox(height: 16),
+
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: Container(
@@ -166,9 +111,12 @@ class _CirclesScreenState extends State<CirclesScreen> {
                           hintText: 'Search circles',
                           border: InputBorder.none,
                         ),
-                        onChanged: (value) => setState(() {
-                          _searchQuery = value;
-                        }),
+                        textInputAction: TextInputAction.search,
+                        onChanged: (v) => setState(() => _searchQuery = v),
+                        onSubmitted: (v) {
+                          setState(() => _searchQuery = v);
+                          FocusScope.of(context).unfocus();
+                        },
                       ),
                     ),
                   ],
@@ -177,97 +125,16 @@ class _CirclesScreenState extends State<CirclesScreen> {
             ),
             const SizedBox(height: 16),
             const Divider(),
+
             Expanded(
-              child: ListView.separated(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                itemCount: circlesToShow.length,
-                separatorBuilder: (_, __) => const Divider(height: 24),
-                itemBuilder: (context, index) {
-                  final circle = circlesToShow[index];
-                  return ListTile(
-                    leading: Stack(
-                      children: [
-                        Container(
-                          width: 48,
-                          height: 48,
-                          decoration: BoxDecoration(
-                            border: Border.all(color: Colors.grey),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: const Icon(
-                            Icons.group,
-                            size: 28,
-                            color: Colors.grey,
-                          ),
-                        ),
-                        const Positioned(
-                          top: -4,
-                          right: -4,
-                          child: Icon(
-                            Icons.check_circle,
-                            color: Colors.blue,
-                            size: 20,
-                          ),
-                        ),
-                      ],
-                    ),
-                    title: Text(circle['name']),
-                    subtitle: Text('${circle['members']} members'),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => CircleDetailScreen(
-                            circle: {
-                              'name': circle['name'],
-                              'subtitle': 'Feel free',
-                              'members': circle['members'],
-                              'created': '2025-07-23',
-                              'admins': 'Yechan(Paul) Kim',
-                            },
-                          ),
-                        ),
-                      );
-                    },
-                  );
-                },
-              ),
+              child: selectedTab == 0
+                  ? _buildMyCirclesList()
+                  : _buildExploreList(),
             ),
           ],
         ),
       ),
-      // bottomNavigationBar: Container(
-      //   decoration: BoxDecoration(
-      //     color: Colors.white,
-      //     boxShadow: [
-      //       BoxShadow(
-      //         color: Colors.grey.withOpacity(0.2),
-      //         blurRadius: 4,
-      //         offset: const Offset(0, -2),
-      //       ),
-      //     ],
-      //   ),
-      //   child: BottomNavigationBar(
-      //     type: BottomNavigationBarType.fixed,
-      //     currentIndex: _currentIndex,
-      //     onTap: _onItemTapped,
-      //     selectedItemColor: Colors.black,
-      //     unselectedItemColor: Colors.grey,
-      //     items: const [
-      //       BottomNavigationBarItem(icon: Icon(Icons.rss_feed), label: 'Feed'),
-      //       BottomNavigationBarItem(
-      //         icon: Icon(Icons.emoji_events),
-      //         label: 'Board',
-      //       ),
-      //       BottomNavigationBarItem(
-      //         icon: Icon(Icons.add_circle),
-      //         label: 'Add Task',
-      //       ),
-      //       BottomNavigationBarItem(icon: Icon(Icons.people), label: 'Circles'),
-      //       BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
-      //     ],
-      //   ),
+
       bottomNavigationBar: Container(
         decoration: BoxDecoration(
           color: Colors.white,
@@ -283,33 +150,167 @@ class _CirclesScreenState extends State<CirclesScreen> {
           type: BottomNavigationBarType.fixed,
           backgroundColor: Colors.white,
           currentIndex: _currentIndex,
-          onTap: _onItemTapped,
+          onTap: _onNavItemTapped,
           selectedItemColor: Colors.black,
           unselectedItemColor: Colors.grey,
-          items: [
+          items: const [
             BottomNavigationBarItem(
-              icon: Image.asset('assets/feed.png', height: 30),
+              icon: Image(image: AssetImage('assets/feed.png'), height: 30),
               label: 'Feed',
             ),
             BottomNavigationBarItem(
-              icon: Image.asset('assets/board_logo.png', height: 30),
+              icon: Image(
+                image: AssetImage('assets/board_logo.png'),
+                height: 30,
+              ),
               label: 'Board',
             ),
             BottomNavigationBarItem(
-              icon: Image.asset('assets/tasks_logo.png', height: 30),
+              icon: Image(
+                image: AssetImage('assets/tasks_logo.png'),
+                height: 30,
+              ),
               label: 'Add Task',
             ),
             BottomNavigationBarItem(
-              icon: Image.asset('assets/circles.png', height: 30),
+              icon: Image(image: AssetImage('assets/circles.png'), height: 30),
               label: 'Circles',
             ),
             BottomNavigationBarItem(
-              icon: const Icon(Icons.person, size: 30),
+              icon: Icon(Icons.person, size: 30),
               label: 'Profile',
             ),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildTabButton(String label, int tabIndex, {required bool left}) {
+    final isSelected = selectedTab == tabIndex;
+    return SizedBox(
+      width: 140,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: isSelected
+              ? const LinearGradient(colors: [Colors.pinkAccent, Colors.blue])
+              : null,
+          color: isSelected ? null : Colors.white,
+          borderRadius: left
+              ? const BorderRadius.horizontal(left: Radius.circular(8))
+              : const BorderRadius.horizontal(right: Radius.circular(8)),
+          border: Border.all(color: Colors.grey),
+        ),
+        child: TextButton(
+          onPressed: () => setState(() => selectedTab = tabIndex),
+          style: TextButton.styleFrom(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              color: isSelected ? Colors.white : Colors.black,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMyCirclesList() {
+    final filtered = myCircles
+        .where(
+          (c) => c['name'].toLowerCase().contains(_searchQuery.toLowerCase()),
+        )
+        .toList();
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      itemCount: filtered.length,
+      separatorBuilder: (_, __) => const Divider(height: 24),
+      itemBuilder: (ctx, i) {
+        final circle = filtered[i];
+        return ListTile(
+          leading: _buildCircleIcon(),
+          title: Text(circle['name']),
+          subtitle: Text('${circle['members']} members'),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {
+            Navigator.push(
+              ctx,
+              MaterialPageRoute(
+                builder: (_) => CircleDetailScreen(
+                  circle: {
+                    'name': circle['name'],
+                    'subtitle': '${circle['members']} members',
+                    'members': circle['members'],
+                    'created': DateTime.now().toIso8601String(),
+                    'admins': '',
+                  },
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildExploreList() {
+    return FutureBuilder<List<Map<String, dynamic>>>(
+      future: _exploreFuture,
+      builder: (ctx, snap) {
+        if (snap.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final list = snap.data!
+            .where(
+              (c) =>
+                  c['name'].toLowerCase().contains(_searchQuery.toLowerCase()),
+            )
+            .toList();
+        return ListView.separated(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          itemCount: list.length,
+          separatorBuilder: (_, __) => const Divider(height: 24),
+          itemBuilder: (ctx, i) {
+            final item = list[i];
+            return ListTile(
+              leading: _buildCircleIcon(),
+              title: Text(item['name']),
+              subtitle: Text('${item['members']} members'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => Navigator.push(
+                ctx,
+                MaterialPageRoute(
+                  builder: (_) => CircleDetailScreen(circle: item),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildCircleIcon() {
+    return Stack(
+      children: [
+        Container(
+          width: 48,
+          height: 48,
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.grey),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: const Icon(Icons.group, size: 28, color: Colors.grey),
+        ),
+        const Positioned(
+          top: -4,
+          right: -4,
+          child: Icon(Icons.check_circle, color: Colors.blue, size: 20),
+        ),
+      ],
     );
   }
 }

--- a/src/wellth_app/lib/pages/landing_page.dart
+++ b/src/wellth_app/lib/pages/landing_page.dart
@@ -27,7 +27,7 @@ class LandingPageScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<LandingPageScreen> {
-  int _currentIndex = 4;
+  int _currentIndex = 2;
   // Growable list of tasks
   List<Task> quests = List<Task>.from([
     Task('Walk 10k steps', 5, completed: true),
@@ -451,10 +451,8 @@ class _HomeScreenState extends State<LandingPageScreen> {
     setState(() => _currentIndex = index);
     switch (index) {
       case 0:
-        Navigator.pushReplacementNamed(context, '/CircleFeed');
         break;
       case 1:
-        Navigator.pushReplacementNamed(context, '/CircleDetail');
         break;
       case 2:
         break;

--- a/src/wellth_app/lib/pages/profile_page.dart
+++ b/src/wellth_app/lib/pages/profile_page.dart
@@ -83,7 +83,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
         Navigator.pushNamed(context, '/landingPage');
         break;
       case 'Circles':
-        Navigator.pushNamed(context, '/landingPage');
+        Navigator.pushNamed(context, '/Circles');
         break;
       case 'Profile':
         // Already on Profile page, no action needed


### PR DESCRIPTION
- circles.dart
   - Added Firebase logic to select 30 circles.
- main.dart
   - Restored app startup to display the LoginPage.
- profile_page.dart
   - Updated “Circle” button to navigate to the CirclePage.
- circle_page.dart
   - MyCircle tab: Switched to a hard-coded list of circles from the profile.
   - Explore tab: Replaced hard-coded data with Firebase logic to fetch 30 circles.
- landing_page.dart
   - Updated _onNavTapped handler:
- Bottom-navbar onTap logic in all circles_ pages\_*
   - Navigation mapping: Index 0, 1, 2 → /landingPage, Index 3 → /Circles, Index 4 → /userProfile
   - circles_announcement_detail_page.dart
   - circles_announcement_page.dart
   - circles_details_page.dart
   - circles_feeds_page.dart
   - circles_members_page.dart
   - circles_new_announcement_page.dart