### PR TITLE
adding show password and unifying login listener

### DIFF
--- a/src/wellth_app/lib/main.dart
+++ b/src/wellth_app/lib/main.dart
@@ -27,6 +27,7 @@ import 'pages/circles_feeds_page.dart';
 import 'pages/circles_members_page.dart';
 import 'pages/circles_new_announcement_page.dart';
 import 'pages/circles_page.dart';
+import 'pages/route_tracker.dart';
 
 // Added from codelab
 
@@ -86,6 +87,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final routeTracker = RouteTracker();
     return MaterialApp(
       debugShowCheckedModeBanner: false,
 

--- a/src/wellth_app/lib/pages/route_tracker.dart
+++ b/src/wellth_app/lib/pages/route_tracker.dart
@@ -1,0 +1,23 @@
+// lib/navigation/route_tracker.dart
+import 'package:flutter/widgets.dart';
+
+class RouteTracker extends NavigatorObserver {
+  String? lastRoute;
+
+  @override
+  void didPush(Route route, Route? previousRoute) {
+    if (route.settings.name != null) {
+      lastRoute = route.settings.name;
+    }
+  }
+
+  @override
+  void didPop(Route route, Route? previousRoute) {
+    if (previousRoute?.settings.name != null) {
+      lastRoute = previousRoute!.settings.name;
+    }
+  }
+}
+
+/// Expose a single instance that you register in your MaterialApp...
+final RouteTracker routeTracker = RouteTracker();


### PR DESCRIPTION
in this pr im adding the following
- show password toggle on login page
- unifying login page listener, fixing bugs around resign in and signing in a user who has not completed onboarding steps
- fixing google sso to create a user within firebase with same guidelines as the registration page and directing them to the onboarding page 
- defined but did not implement a route observer class so we can call it whenever we need to find the last visited page, still need to work out issues with it, so I have not implemented it in any of the buttons yet, just defined the class

